### PR TITLE
Support multiple authors

### DIFF
--- a/parts/post-meta.php
+++ b/parts/post-meta.php
@@ -20,16 +20,14 @@
 		</svg>
 		<?php echo get_the_date(); ?>
 	</time>
-	<?php if (array_key_exists('author', $args)): ?>
-	<a class="author" href="<?php echo get_author_posts_url( get_the_author_meta( 'ID', $args['author'] ) ); ?>">
+	<span>
 		<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-s" viewBox="0 0 24 24">
 			<path stroke="none" d="M0 0h24v24H0z" fill="none"/>
 			<circle cx="12" cy="7" r="4" />
 			<path d="M6 21v-2a4 4 0 0 1 4 -4h4a4 4 0 0 1 4 4v2" />
 		</svg>
-		<?php echo get_the_author_meta( 'display_name', $args['author'] ); ?>
-	</a>
-	<?php endif; ?>
+		<?php function_exists( 'coauthors_posts_links' ) ? coauthors_posts_links() : the_author_posts_link(); ?>
+	</span>
 	<a class="responses" href="<?php echo rtrim( the_permalink(), '/' ); ?>#c">
 		<svg xmlns="http://www.w3.org/2000/svg" class="icon icon-s" viewBox="0 0 24 24">
 			<path stroke="none" d="M0 0h24v24H0z" fill="none"/>

--- a/single.php
+++ b/single.php
@@ -25,7 +25,7 @@
 			<section class="content">
 				<?php the_category(); ?>
 				<?php the_title( '<h1>', '</h1>' ); ?>
-				<?php get_template_part('parts/post-meta', null, ['author' => get_the_author_meta('ID')]); ?>
+				<?php get_template_part('parts/post-meta'); ?>
 				<?php the_content(); ?>
 				<?php get_template_part('parts/post-tags'); ?>
 			</section>

--- a/style.css
+++ b/style.css
@@ -521,11 +521,12 @@ main.post .content .meta {
 	color: var(--c-primary-low-accent2);
 	margin-bottom: 3rem;
 	display: flex;
-	gap: 1.5rem;
+	gap: .25rem 1.5rem;
 	flex-wrap: wrap;
 }
 main.post .content .meta > * {
 	display: flex;
+	flex-wrap: wrap;
 	align-items: center;
 	gap: 0.25rem;
 }

--- a/style.css
+++ b/style.css
@@ -430,19 +430,15 @@ main > .featured article a.title:hover {
 	text-decoration: underline;
 }
 main > .featured article .meta {
+	color: var(--c-primary-high);
 	display: flex;
 	gap: 1.5rem;
 	flex-wrap: wrap;
 }
 main > .featured article .meta > * {
-	color: var(--c-primary-high);
-	text-decoration: none;
 	display: flex;
 	align-items: center;
 	gap: 0.25rem;
-}
-main > .featured article .meta > a:hover {
-	text-decoration: underline;
 }
 main > .featured article .meta .icon {
 	stroke: var(--c-primary-high);
@@ -522,13 +518,13 @@ main.post .content .post-categories > li a {
 	color: white;
 }
 main.post .content .meta {
+	color: var(--c-primary-low-accent2);
 	margin-bottom: 3rem;
 	display: flex;
 	gap: 1.5rem;
 	flex-wrap: wrap;
 }
 main.post .content .meta > * {
-	color: var(--c-primary-low-accent2);
 	display: flex;
 	align-items: center;
 	gap: 0.25rem;


### PR DESCRIPTION
This change adds support for the "Co-Authors Plus" plugin and shows all authors on the featured article preview and on the article page. It also adds styles for meta links to highlight them as clickable.

Before:
![image](https://github.com/thunderbird/thunderblog/assets/5441654/2de7f711-171b-4f72-bdfa-14ac31dbe5bc)

After:
![image](https://github.com/thunderbird/thunderblog/assets/5441654/42463183-73d5-4eac-abfe-0c2fb8d8009b)

Implements #50 