### PR TITLE
Fix footer logo click box

### DIFF
--- a/style.css
+++ b/style.css
@@ -285,17 +285,19 @@ footer {
 	color: white;
 	margin-top: 5rem;
 	padding: 3rem 2rem 5rem 2rem;
+	display: flex;
+  flex-direction: column;
+  gap: 2rem;
 }
 footer .logo {
-	display: block;
-	text-align: center;
-	margin-bottom: 2rem;;
+	align-self: center;
 }
 footer .logo img {
 	height: 48px;
 }
 footer hr {
 	max-width: var(--content-width);
+	width: 100%;
 	margin: 3rem auto;
 }
 footer .columns {


### PR DESCRIPTION
This change makes the footer a flex container and fixes the logo to be only clickable on the image itself.

![image](https://github.com/thunderbird/thunderblog/assets/5441654/8fc632c8-779d-4703-9d7b-05ffd84b250e)

Closes #29 