### PR TITLE
Rearrange featured post

### DIFF
--- a/index.php
+++ b/index.php
@@ -21,18 +21,20 @@
 	?>
 	<?php if ( $post ) : ?>
 		<article>
+			<span class="category"><?php _e( isset( $sticky[0] ) ? 'Featured Post' : 'Latest Post', 'thunderblog' ); ?></span>
+			<a class="title" href="<?php the_permalink( $post ); ?>">
+				<h1><?php echo $post->post_title; ?></h1>
+			</a>
 			<div class="content">
-				<span class="category"><?php _e( isset( $sticky[0] ) ? 'Featured Post' : 'Latest Post', 'thunderblog' ); ?></span>
-				<a class="title" href="<?php the_permalink( $post ); ?>">
-					<h1><?php echo $post->post_title; ?></h1>
-				</a>
-				<?php get_template_part( 'parts/post-meta', null, array( 'author' => $post->post_author) ); ?>
-				<div class="description"><?php the_excerpt( $post ) ?></div>
-				<a class="btn btn-neutral-light" href="<?php the_permalink( $post ); ?>"><?php _e( 'Read more', 'thunderblog' ); ?></a>
+				<div>
+					<?php get_template_part( 'parts/post-meta', null, array( 'author' => $post->post_author) ); ?>
+					<div class="description"><?php the_excerpt( $post ) ?></div>
+					<a class="btn btn-neutral-light" href="<?php the_permalink( $post ); ?>"><?php _e( 'Read more', 'thunderblog' ); ?></a>
+				</div>
+				<?php if ( has_post_thumbnail( $post ) ) : ?>
+					<img class="d-init-xl" src="<?php echo get_the_post_thumbnail_url( $post ); ?>" alt="featured article title image">
+				<?php endif; ?>
 			</div>
-			<?php if ( has_post_thumbnail( $post ) ) : ?>
-				<img class="d-init-xl" src="<?php echo get_the_post_thumbnail_url( $post ); ?>" alt="featured article title image">
-			<?php endif; ?>
 		</article>
 	<?php endif; ?>
 	</section>

--- a/style.css
+++ b/style.css
@@ -407,14 +407,9 @@ main > .featured {
 	padding: 0 1rem;
 }
 main > .featured article {
-	position: relative;
 	color: white;
 	margin: 2rem 0 3rem 0;
 	max-width: var(--content-width);
-	display: grid;
-	grid-template-columns: 1fr;
-	align-items: center;
-	gap: 2rem;
 }
 main > .featured img {
 	max-height: calc(var(--featured-height) - 6rem);
@@ -431,6 +426,12 @@ main > .featured article a.title {
 }
 main > .featured article a.title:hover {
 	text-decoration: underline;
+}
+main > .featured article .content {
+	display: grid;
+	grid-template-columns: 1fr;
+	align-items: center;
+	gap: 2rem;
 }
 main > .featured article .meta {
 	color: var(--c-primary-high);
@@ -685,9 +686,6 @@ nav.pagination .nav-links > span.current {
 	main > .articles {
 		grid-template-columns: 1fr 1fr;
 	}
-	main > .featured article .description {
-		max-width: 60%;
-	}
 	.d-none-m { display: none !important; }
 	.d-init-m { display: initial !important; }
 	.d-flex-m { display: flex !important; }
@@ -703,8 +701,8 @@ nav.pagination .nav-links > span.current {
 	main > .articles {
 		grid-template-columns: 1fr 1fr 1fr;
 	}
-	main > .featured article {
-		grid-template-columns: 3fr 2fr;
+	main > .featured article .content {
+		grid-template-columns: 1fr 1fr;
 	}
 	.d-none-xl,
 	nav.mobile-nav.active { display: none !important; }


### PR DESCRIPTION
This change rearranges the featured post on the home page by giving the title the whole width and description and image beneath both 50%. Not on mobile obviously.

![image](https://github.com/thunderbird/thunderblog/assets/5441654/a9f185ac-03d2-4e3f-98cf-228c13c1e489)

Closes #55 