### PR TITLE
Align wide support for embeds

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -17,6 +17,8 @@ add_theme_support( 'post-thumbnails' );
 add_theme_support( 'title-tag' );
 // enable automatic RSS links in the header
 add_theme_support( 'automatic-feed-links' );
+// enable alignment block options
+add_theme_support( 'align-wide' );
 
 // navigation menus for top and footer menu
 function thunderblog_register_menus() {

--- a/style.css
+++ b/style.css
@@ -573,6 +573,16 @@ main.post .content figure.alignleft {
 main.post .content figure.alignright {
 	margin-left: 1rem;
 }
+main.post .content figure.alignwide,
+main.post .content figure.alignfull {
+	width: 100%;
+
+	&.wp-block-embed.wp-embed-aspect-16-9 iframe {
+		width: 100%;
+		height: auto;
+		aspect-ratio: 16/9;
+	}
+}
 main.post .tags {
 	display: flex;
 	gap: .5rem;


### PR DESCRIPTION
This change enables the align-wide block options and sets styles especially for embeds with 16:9 aspect ratio. Setting align-wide or align-full on a youtube embed in the block editor makes the video as wide as the surrounding text:

![image](https://github.com/thunderbird/thunderblog/assets/5441654/e29fa1fe-baaf-48f8-81f7-afaa3bb7655d)

Closes #60 